### PR TITLE
[REVIEW ONLY] Remove monkey patch of CSV#init_converters for ruby 2.5

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -38,13 +38,18 @@ module Csvlint
         ESCAPE_RE[@re_chars][@re_esc][str]
       end
 
-      # Optimization: Disable the CSV library's converters feature.
-      # @see https://github.com/ruby/ruby/blob/v2_2_3/lib/csv.rb#L2100
-      def init_converters(options, field_name = :converters)
-        @converters = []
-        @header_converters = []
-        options.delete(:unconverted_fields)
-        options.delete(field_name)
+      # This monkey patch is not compatible anymore when ruby 2.5 is introduced
+      # - https://docs.ruby-lang.org/en/2.4.0/CSV.html#method-i-encode_re
+      # - https://docs.ruby-lang.org/en/2.5.0/CSV.html#method-i-encode_re
+      if RUBY_VERSION < '2.5'
+        # Optimization: Disable the CSV library's converters feature.
+        # @see https://github.com/ruby/ruby/blob/v2_2_3/lib/csv.rb#L2100
+        def init_converters(options, field_name = :converters)
+          @converters = []
+          @header_converters = []
+          options.delete(:unconverted_fields)
+          options.delete(field_name)
+        end
       end
     end
 


### PR DESCRIPTION
## Background

- `csvlint` library monkey patched the method `CSV#init_converters`
  - https://github.com/theodi/csvlint.rb/blob/master/lib/csvlint/validate.rb#L43-L49
- It's not compatible with ruby `2.5.0`
  - In ruby `2.4.0`, it only accepts two arguments:
    - https://docs.ruby-lang.org/en/2.4.0/CSV.html#method-i-init_converters
  - However, in ruby `2.5.0`, the required arguments are increased to three
    - https://docs.ruby-lang.org/en/2.5.0/CSV.html#method-i-init_converters

### Conclusion

- Since `csvlint` doesn't support ruby `2.5.0` yet, we have to either:
  - Wait until they support it
  - Fork the library and make our own patch (this PR)

- I'm in favor of the latter since we want to take advantage of ruby `2.5` performance benefits without being blocked by a single dependency.

Please review @quipper/web-devs 
